### PR TITLE
Update ngx-payment-card.component.html

### DIFF
--- a/projects/ngx-payment-card/src/lib/ngx-payment-card.component.html
+++ b/projects/ngx-payment-card/src/lib/ngx-payment-card.component.html
@@ -25,7 +25,7 @@
                       <text class="st7 st5 st8" transform="matrix(1 0 0 1 65.1054 241.5)">{{this.IBAN_Text}}</text>
                       <g>
                             <text class="st2 st5 st9" id="svgexpire"
-                                  transform="matrix(1 0 0 1 574.4219 433.8095)">{{ this.expirationDate | date }}
+                                  transform="matrix(1 0 0 1 574.4219 433.8095)">{{ this.expirationDate }}
                               </text>
                         <text class="st2 st10 st11" transform="matrix(1 0 0 1 479.3848 417.0097)">VALID</text>
                         <text class="st2 st10 st11" transform="matrix(1 0 0 1 479.3848 435.6762)">THRU</text>


### PR DESCRIPTION
The card expiration date, typically represented as MM/YY or MM/AA, is commonly treated as a textual information rather than a specific date data type. There are several reasons for this:

Standardized Format: The card expiration date format is consistent and standardized. It consists of two digits for the month (MM) and two digits for the year (YY or AA). This format makes it easier for users to input and view the card expiration date.

Simplified Validation: Treating the expiration date as a string simplifies the validation process for user input. It allows for applying specific rules to check if the string contains exactly four digits (two for the month and two for the year) and if those digits fall within the appropriate range (e.g., the month is between 01 and 12, and the year is in the future).

Flexible Display: By using a string to represent the expiration date, there is more flexibility in displaying the information according to different contexts. The string can be formatted in various ways, such as adding a slash (/) between the month and year or displaying only the last two digits of the year. This flexibility makes it easier to adapt the date display in different interfaces and scenarios.

Integration with APIs and External Systems: In many cases, when dealing with integrations with third-party systems like payment processors, the card expiration date is expected as a string. This is how external systems typically receive and process this information, facilitating data exchange between different systems.

Considering these points, it is justified to treat the card expiration date as a string as it offers simplicity, standardization, and flexibility in processing, validating, and displaying the information.