### PR TITLE
Update ngx-payment-card.component.scss

### DIFF
--- a/projects/ngx-payment-card/src/lib/ngx-payment-card.component.scss
+++ b/projects/ngx-payment-card/src/lib/ngx-payment-card.component.scss
@@ -218,7 +218,7 @@ label {
 }
 
 #cardfront .iban {
-  font-size: 4rem !important;
+  font-size: 3rem !important;
 }
 
 #cardfront .st2 {


### PR DESCRIPTION
Adjust the Iban font to not exceed the size of the card. This change is necessary, because visually the structure of the component isn't functional.